### PR TITLE
feat: use CGPreflightScreenCaptureAccess API for ScreenAuthStatus

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         npm install
         npm run lint
+      env:
+        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
         npm install
         npm run lint
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
         npm install
         npm test
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         npm install
         npm test
+      env:
+        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
     "xcode_settings": {
       "MACOSX_DEPLOYMENT_TARGET": "10.10",
       "OTHER_CPLUSPLUSFLAGS": ["-std=c++14", "-stdlib=libc++"],
-      "OTHER_LDFLAGS": ["-framework CoreFoundation -framework CoreLocation -framework CoreGraphics -framework CoreLocation -framework AppKit -framework Speech -framework Contacts -framework Photos -framework EventKit -framework AVFoundation"]
+      "OTHER_LDFLAGS": ["-framework CoreBluetooth -framework CoreFoundation -framework CoreLocation -framework CoreGraphics -framework CoreLocation -framework AppKit -framework Speech -framework Contacts -framework Photos -framework EventKit -framework AVFoundation"]
     }
   }]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
     "xcode_settings": {
       "MACOSX_DEPLOYMENT_TARGET": "10.10",
       "OTHER_CPLUSPLUSFLAGS": ["-std=c++14", "-stdlib=libc++"],
-      "OTHER_LDFLAGS": ["-framework CoreBluetooth -framework CoreFoundation -framework CoreLocation -framework AppKit -framework Speech -framework Contacts -framework Photos -framework EventKit -framework AVFoundation"]
+      "OTHER_LDFLAGS": ["-framework CoreFoundation -framework CoreLocation -framework CoreGraphics -framework CoreLocation -framework AppKit -framework Speech -framework Contacts -framework Photos -framework EventKit -framework AVFoundation"]
     }
   }]
 }

--- a/permissions.mm
+++ b/permissions.mm
@@ -6,6 +6,7 @@
 #import <Contacts/Contacts.h>
 #import <CoreBluetooth/CoreBluetooth.h>
 #import <CoreLocation/CoreLocation.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <EventKit/EventKit.h>
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>

--- a/permissions.mm
+++ b/permissions.mm
@@ -183,41 +183,11 @@ std::string FDAAuthStatus() {
 std::string ScreenAuthStatus() {
   std::string auth_status = kNotDetermined;
   if (@available(macOS 10.15, *)) {
-    auth_status = kDenied;
-    NSRunningApplication *runningApplication =
-        NSRunningApplication.currentApplication;
-    NSNumber *ourProcessIdentifier =
-        [NSNumber numberWithInteger:runningApplication.processIdentifier];
-
-    CFArrayRef windowList =
-        CGWindowListCopyWindowInfo(kCGWindowListOptionAll, kCGNullWindowID);
-    int numberOfWindows = CFArrayGetCount(windowList);
-    for (int index = 0; index < numberOfWindows; index++) {
-      // Get information for each window.
-      NSDictionary *windowInfo =
-          (NSDictionary *)CFArrayGetValueAtIndex(windowList, index);
-      NSString *windowName = windowInfo[(id)kCGWindowName];
-      NSNumber *processIdentifier = windowInfo[(id)kCGWindowOwnerPID];
-
-      // Don't check windows owned by the current process.
-      if (![processIdentifier isEqual:ourProcessIdentifier]) {
-        // Get process information for each window.
-        pid_t pid = processIdentifier.intValue;
-        NSRunningApplication *windowRunningApplication =
-            [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
-        if (windowRunningApplication) {
-          NSString *windowExecutableName =
-              windowRunningApplication.executableURL.lastPathComponent;
-          if (windowName) {
-            if (![windowExecutableName isEqual:@"Dock"]) {
-              auth_status = kAuthorized;
-              break;
-            }
-          }
-        }
-      }
+    if (CGPreflightScreenCaptureAccess()) {
+      auth_status = kAuthorized;
+    } else {
+      auth_status = kDenied;
     }
-    CFRelease(windowList);
   } else {
     auth_status = kAuthorized;
   }


### PR DESCRIPTION
Based on this: https://stackoverflow.com/a/65423834/5522263, Apple has an official API to get Screen Auth permission status: `CGPreflightScreenCaptureAccess`: https://developer.apple.com/documentation/coregraphics/3656523-cgpreflightscreencaptureaccess

I've tested this with Electron 11.1.1 + macOS 11 and it worked perfectly.