### PR TITLE
feat: use new CGPreFlightScreenCaptureAccess and CGRequestScreenCaptureAccess API on MacOS 11+

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         npm install
         npm run lint
+      env:
+        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,5 +21,3 @@ jobs:
       run: |
         npm install
         npm run lint
-      env:
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,5 @@ jobs:
       run: |
         npm install
         npm test
+      env:
+        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,3 @@ jobs:
       run: |
         npm install
         npm test
-      env:
-        SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

--- a/binding.gyp
+++ b/binding.gyp
@@ -27,6 +27,7 @@
         "-framework CoreBluetooth",
         "-framework CoreFoundation",
         "-framework CoreLocation",
+        "-framework CoreGraphics",
         "-framework Contacts",
         "-framework EventKit",
         "-framework Photos",

--- a/permissions.mm
+++ b/permissions.mm
@@ -6,6 +6,7 @@
 #import <Contacts/Contacts.h>
 #import <CoreBluetooth/CoreBluetooth.h>
 #import <CoreLocation/CoreLocation.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import <EventKit/EventKit.h>
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>
@@ -202,7 +203,13 @@ std::string FDAAuthStatus() {
 // Screen Capture access.
 std::string ScreenAuthStatus() {
   std::string auth_status = kNotDetermined;
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11, *)) {
+    if (CGPreflightScreenCaptureAccess()) {
+      auth_status = kAuthorized;
+    } else {
+      auth_status = kDenied;
+    }
+  } else if (@available(macOS 10.15, *)) {
     auth_status = kDenied;
     NSRunningApplication *runningApplication =
         NSRunningApplication.currentApplication;
@@ -696,7 +703,9 @@ Napi::Promise AskForMusicLibraryAccess(const Napi::CallbackInfo &info) {
 
 // Request Screen Capture Access.
 void AskForScreenCaptureAccess(const Napi::CallbackInfo &info) {
-  if (@available(macOS 10.15, *)) {
+  if (@available(macOS 11, *)) {
+    CGRequestScreenCaptureAccess();
+  } else if (@available(macOS 10.15, *)) {
     // Tries to create a capture stream. This is necessary to add the app back
     // to the list in sysprefs if the user previously denied.
     // https://stackoverflow.com/questions/56597221/detecting-screen-recording-settings-on-macos-catalina

--- a/permissions.mm
+++ b/permissions.mm
@@ -5,8 +5,8 @@
 #import <AppKit/AppKit.h>
 #import <Contacts/Contacts.h>
 #import <CoreBluetooth/CoreBluetooth.h>
-#import <CoreLocation/CoreLocation.h>
 #import <CoreGraphics/CoreGraphics.h>
+#import <CoreLocation/CoreLocation.h>
 #import <EventKit/EventKit.h>
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>


### PR DESCRIPTION
MacOS 11 introduces 2 new APIs for requesting and checking screen capture access.

https://developer.apple.com/documentation/coregraphics/3656523-cgpreflightscreencaptureaccess

And

https://developer.apple.com/documentation/coregraphics/3656524-cgrequestscreencaptureaccess

The documentation says 10.15+ but its wrong and it only seems to work on 11+