### PR TITLE
chore(deps): specify operating system

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "*.mm": [
       "clang-format -i"
     ]
-  }
+  },
+  "os": ["darwin"]
 }


### PR DESCRIPTION
This makes sure yarn/npm stops early before trying to build and install on non-macOS platforms.

> The platform "linux" is incompatible with this module.
> The platform "win32" is incompatible with this module.

Same as https://github.com/codebytere/node-mac-contacts/pull/21 and #27 (which was closed automatically by the master → main branch rename). 
