### PR TITLE
Add release CI workflow to build and release universal binary

### DIFF
--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -1,0 +1,67 @@
+name: Create tagged release
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch: [ "x64", "arm64" ]
+    runs-on: macos-11
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install
+        run: npm install
+      - name: Build
+        run: npm run build -- -a ${{matrix.arch}}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: permissions-${{matrix.arch}}
+          path: build/Release/permissions.node
+
+  deploy:
+    needs:
+      - build
+    runs-on: macos-11
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install
+        run: npm install
+      - name: Create directories
+        run: |
+          mkdir -p build/Release
+          mkdir -p /tmp/artifacts/x64
+          mkdir -p /tmp/artifacts/arm64
+      - name: Download x64 artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: permissions-x64
+          path: /tmp/artifacts/x64
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: permissions-arm64
+          path: /tmp/artifacts/arm64
+      - name: Build universal binary
+        run: |
+          lipo /tmp/artifacts/x64/permissions.node /tmp/artifacts/arm64/permissions.node -create -output build/Release/permissions.node
+          ls -la build/Release
+          lipo -info build/Release/permissions.node
+#      - name: Publish tagged release
+#        uses: JS-DevTools/npm-publish@v1
+#        with:
+#          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           lipo /tmp/artifacts/x64/permissions.node /tmp/artifacts/arm64/permissions.node -create -output build/Release/permissions.node
           lipo -info build/Release/permissions.node
-#      - name: Publish tagged release
-#        uses: JS-DevTools/npm-publish@v1
-#        with:
-#          token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish tagged release
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 18
       - name: Install
-        run: npm install
+        run: npm install --ignore-scripts
       - name: Build
         run: npm run build -- -a ${{matrix.arch}}
       - name: Upload artifact
@@ -40,7 +40,7 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
       - name: Install
-        run: npm install
+        run: npm install --ignore-scripts
       - name: Create directories
         run: |
           mkdir -p build/Release
@@ -59,7 +59,6 @@ jobs:
       - name: Build universal binary
         run: |
           lipo /tmp/artifacts/x64/permissions.node /tmp/artifacts/arm64/permissions.node -create -output build/Release/permissions.node
-          ls -la build/Release
           lipo -info build/Release/permissions.node
 #      - name: Publish tagged release
 #        uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
This PR introduces a dedicated CI workflow for tagged releases.

Not only does it automate releases, it also enables publishing a [universal binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) which natively runs on both Intel and Apple Silicon machines, not need for Rosetta2.

It achieves this by first building two separate binaries for x64 and arm64 that are later combined into a single fat binary that supports both architectures.

**Requirements**: 

In order to publish new releases, this CI workflow requires a [repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) called **NPM_TOKEN** which stores an [npm automation access token](https://docs.npmjs.com/creating-and-viewing-access-tokens).

**How to use**:

A new release will be published by pushing a new tag:

```bash
git tag -a v2.2.2 -m "Release v2.2.2"
git push --tags
```

Please note that this workflow will only run on tags that follow the form `v*.*.*`, e.g. `v2.2.2`