### PR TITLE
fix: force System Prefs for screen capture on macOS 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,11 @@ askForPhotosAccess().then(status => {
 })
 ```
 
-### `permissions.askForScreenCaptureAccess()`
+### `permissions.askForScreenCaptureAccess([openPreferences])`
 
-There is no API for programmatically requesting Screen Capture on macOS at this time, and so calling this method will trigger opening of System Preferences at the Screen Capture pane of Security and Privacy.
+* `openPreferences` Boolean (optional) - Whether to open System Preferences if the request to authorize Screen Capture fails or is denied by the user.
+
+Calling this method for the first time within an app session will trigger a permission modal. If this modal is denied, there is no  API for programmatically requesting Screen Capture on macOS at this time. Calling this method after denial with `openPreferences = true` will trigger opening of System Preferences at the Screen Capture pane of Security and Privacy.
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,14 @@ function askForFoldersAccess(folder) {
   return permissions.askForFoldersAccess.call(this, folder)
 }
 
+function askForScreenCaptureAccess(openPreferences = false) {
+  if (typeof openPreferences !== 'boolean') {
+    throw new TypeError('openPreferences must be a boolean')
+  }
+
+  return permissions.askForScreenCaptureAccess.call(this, openPreferences)
+}
+
 function askForPhotosAccess(accessLevel = 'add-only') {
   if (!['add-only', 'read-write'].includes(accessLevel)) {
     throw new TypeError(`${accessLevel} must be one of either 'add-only' or 'read-write'`)
@@ -57,6 +65,6 @@ module.exports = {
   askForMusicLibraryAccess: permissions.askForMusicLibraryAccess,
   askForPhotosAccess,
   askForSpeechRecognitionAccess: permissions.askForSpeechRecognitionAccess,
-  askForScreenCaptureAccess: permissions.askForScreenCaptureAccess,
+  askForScreenCaptureAccess,
   getAuthStatus,
 }

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { askForFoldersAccess, getAuthStatus } = require('../index')
+const { askForFoldersAccess, getAuthStatus, askForScreenCaptureAccess } = require('../index')
 
 describe('node-mac-permissions', () => {
   describe('getAuthStatus()', () => {
@@ -41,6 +41,14 @@ describe('node-mac-permissions', () => {
       expect(() => {
         askForFoldersAccess('bad-type')
       }).to.throw(/bad-type is not a valid protected folder/)
+    })
+  })
+
+  describe('askForScreenCaptureAccess()', () => {
+    it('should throw on invalid openPreferences type', () => {
+      expect(() => {
+        askForScreenCaptureAccess('bad-type')
+      }).to.throw(/openPreferences must be a boolean/)
     })
   })
 })


### PR DESCRIPTION
Closes https://github.com/codebytere/node-mac-permissions/issues/48.