### PR TITLE
fix: update `StoreKit` naming to support case-sensitive volumes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,7 +33,7 @@
         "-framework IOKit",
         "-framework Photos",
         "-framework Speech",
-        "-framework Storekit"
+        "-framework StoreKit"
       ]
     }
   }]

--- a/permissions.mm
+++ b/permissions.mm
@@ -12,7 +12,7 @@
 #import <IOKit/hidsystem/IOHIDLib.h>
 #import <Photos/Photos.h>
 #import <Speech/Speech.h>
-#import <Storekit/Storekit.h>
+#import <StoreKit/StoreKit.h>
 #import <pwd.h>
 
 /***** HELPER FUNCTIONS *****/


### PR DESCRIPTION
Hi, thanks for your awesome repo, it's quit handy in electron apps :)

However, recently I found that, if the package is installed in a [case-sensitive volumn](https://support.apple.com/lt-lt/guide/disk-utility/dsku19ed921c/mac), the compillation will fail with the error below:

![image](https://user-images.githubusercontent.com/7011247/230611919-cd1dc398-e1dd-434e-902a-699fe5ce1fa7.png)

The problem is that the `Storekit` is different with `StoreKit` in such case-sensitive volumns. In my mac, there's only `StoreKit.framework` rather than `Storekit.framework`:
![image](https://user-images.githubusercontent.com/7011247/230612834-23213bc1-0ab6-41a0-8487-98f06baebe1c.png)

and the `StoreKit` seems to be apple's official framework name(see https://developer.apple.com/documentation/storekit).

This PR simply change `Storekit` into `StoreKit` to support case-sensitive volumes, and the compillation runs successfully. Please have a look :)

